### PR TITLE
Remove some uses of unwrap()

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -15,16 +15,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| Config::default_path());
 
-    tracing::debug!("Config path: {}", config_path.to_str().unwrap());
+    tracing::debug!("Config path: {:?}", config_path);
 
     let config = match Config::read(&config_path) {
         Ok(config) => config,
         Err(ConfigError::IO(err)) => match err.kind() {
             std::io::ErrorKind::NotFound => {
-                tracing::error!(
-                    "Config file could not be found at {}",
-                    config_path.to_str().unwrap()
-                );
+                tracing::error!("Config file could not be found at {:?}", config_path);
                 return Ok(());
             }
             _ => panic!("Read config IO Error: {}", err),

--- a/server/src/oauth/authorize.rs
+++ b/server/src/oauth/authorize.rs
@@ -3,6 +3,7 @@ use super::AuthorizationRequestQuery;
 use crate::State;
 use axum::extract::Extension;
 use axum::extract::Query;
+use houseflow_types::errors::InternalError;
 use houseflow_types::errors::OAuthError;
 use houseflow_types::errors::ServerError;
 
@@ -13,7 +14,11 @@ pub async fn handle(
     Extension(state): Extension<State>,
     Query(request): Query<AuthorizationRequestQuery>,
 ) -> Result<http::Response<axum::body::Body>, ServerError> {
-    let google_config = state.config.google.as_ref().unwrap();
+    let google_config = state
+        .config
+        .google
+        .as_ref()
+        .ok_or_else(|| InternalError::Other("Google Home API not configured".to_string()))?;
     if *request.client_id != *google_config.client_id {
         return Err(OAuthError::InvalidClient(Some(String::from("invalid client id"))).into());
     }

--- a/server/src/oauth/login.rs
+++ b/server/src/oauth/login.rs
@@ -9,6 +9,7 @@ use chrono::Utc;
 use houseflow_types::auth::login::Request;
 use houseflow_types::code::VerificationCode;
 use houseflow_types::errors::AuthError;
+use houseflow_types::errors::InternalError;
 use houseflow_types::errors::OAuthError;
 use houseflow_types::errors::ServerError;
 use houseflow_types::token::AuthorizationCode;
@@ -32,7 +33,11 @@ pub async fn handle(
 ) -> Result<http::Response<axum::body::Body>, ServerError> {
     validator::Validate::validate(&request)?;
 
-    let google_config = state.config.google.as_ref().unwrap();
+    let google_config = state
+        .config
+        .google
+        .as_ref()
+        .ok_or_else(|| InternalError::Other("Google Home API not configured".to_string()))?;
     if *query.client_id != *google_config.client_id {
         return Err(OAuthError::InvalidClient(Some(String::from("invalid client id"))).into());
     }


### PR DESCRIPTION
Return an error rather than panicking if Google config is missing, and avoid an unwrap when formatting a `Path` for debug output.