### PR TITLE
Add support for Houseflow server to act as a Homie controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,10 +220,10 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.1",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.1",
  "tower-service",
 ]
 
@@ -294,6 +305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +349,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -512,6 +538,12 @@ checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fallible-iterator"
@@ -801,6 +833,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "homie-controller"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6bd949129321447a71afe7942ac2fe8b06d270b12866a37ca6405ed9890cdb6"
+dependencies = [
+ "log",
+ "rumqttc",
+ "thiserror",
+]
+
+[[package]]
 name = "houseflow-api"
 version = "0.1.1"
 dependencies = [
@@ -899,6 +942,7 @@ dependencies = [
  "futures-util",
  "google-smart-home",
  "headers",
+ "homie-controller",
  "houseflow-config",
  "houseflow-types",
  "http",
@@ -909,7 +953,10 @@ dependencies = [
  "lazy_static",
  "lettre",
  "rand",
+ "rumqttc",
  "rust-argon2",
+ "rustls 0.19.1",
+ "rustls-native-certs",
  "semver",
  "serde",
  "serde_json",
@@ -1138,7 +1185,7 @@ dependencies = [
  "once_cell",
  "quoted_printable",
  "regex",
- "rustls",
+ "rustls 0.20.1",
  "rustls-pemfile",
  "webpki-roots",
 ]
@@ -1249,6 +1296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "mqttbytes"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d710573f2144656d97b82b7ad85c464a1c35ae065278fbee545d40034ec1de5a"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -1468,6 +1524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
+name = "pollster"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb20dcc30536a1508e75d47dd0e399bb2fe7354dcf35cda9127f2bf1ed92e30e"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1737,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd4cf48aa8588d907fc835c47fbc8ef01dc30552467fbf0123cd794f77fd2072"
+dependencies = [
+ "async-channel",
+ "bytes",
+ "http",
+ "log",
+ "mqttbytes",
+ "pollster",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,14 +1783,39 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.0",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac4581f0fc0e0efd529d069e8189ec7b90b8e7680e21beb35141bdc45f36040"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1749,6 +1854,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -2137,13 +2252,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4baa378e417d780beff82bf54ceb0d195193ea6a00c14e22359e7f39456b5689"
 dependencies = [
- "rustls",
+ "rustls 0.20.1",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2167,11 +2293,11 @@ checksum = "e057364a4dd37870b33bf8dc1885d29187d90770f488d599d3ee8d9e4916fbd3"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.20.1",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.1",
  "tungstenite 0.16.0",
- "webpki",
+ "webpki 0.22.0",
  "webpki-roots",
 ]
 
@@ -2340,12 +2466,12 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.20.1",
  "sha-1",
  "thiserror",
  "url",
  "utf-8",
- "webpki",
+ "webpki 0.22.0",
  "webpki-roots",
 ]
 
@@ -2584,6 +2710,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -2598,7 +2734,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/config/src/server/mod.rs
+++ b/config/src/server/mod.rs
@@ -380,6 +380,7 @@ mod tests {
                     username: String::from("gbaranski"),
                     email: String::from("root@gbaranski.com"),
                     admin: false,
+                    homie: None,
                 }
             ].to_vec(),
             permissions: [
@@ -414,12 +415,14 @@ mod tests {
             username: String::from("gbaranski"),
             email: String::from("root@gbaranski.com"),
             admin: false,
+            homie: None,
         };
         let user_unauth = User {
             id: user::ID::new_v4(),
             username: String::from("stanbar"),
             email: String::from("stanbar@gbaranski.com"),
             admin: false,
+            homie: None,
         };
         let structure_auth = Structure {
             id: structure::ID::new_v4(),

--- a/config/src/server/mod.rs
+++ b/config/src/server/mod.rs
@@ -43,7 +43,7 @@ pub struct Config {
     /// Devices
     #[serde(default)]
     pub devices: Vec<Device>,
-    /// Devices
+    /// Users
     #[serde(default)]
     pub users: Vec<User>,
     /// User -> Structure permission

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -65,8 +65,12 @@ lettre = { version = "0.10.0-rc.4", default-features = false, features = [
 base64 = "0.13.0"
 bincode = "1.3.3"
 axum-server = { version = "0.3.2", features = ["tls-rustls"] }
+homie-controller = "0.4.0"
 jsonwebtoken-google = "0.1.2"
 jsonwebtoken = "7.2.0"
+rumqttc = "0.8.0"
+rustls = "0.19.1"
+rustls-native-certs = "0.5.0"
 urlencoding = "2.1.0"
 
 [dev-dependencies]

--- a/server/README.md
+++ b/server/README.md
@@ -1,37 +1,45 @@
-# Introducion
-API Server for Houseflow. Built using [axum](https://github.com/tokio-rs/axum), a web framework. 
+# Houseflow API server
 
-# Clients
+API Server for Houseflow. Built using [axum](https://github.com/tokio-rs/axum), a web framework.
 
-Server currently supports two type of clients,
-- Internal, e.g CLI app.
-- G-Home(Google Home).
+## Clients
 
-## auth/
+The server currently supports two type of clients:
+
+- Internal, e.g CLI app
+- Google Home
+
+## Code organisation
+
+The main modules and directories are:
+
+### auth/
 
 Handles internal clients authorization.
 
-## fulfillment/
+### fulfillment/
 
 Fulfillment service supports following intents
 
 - Sync, get all available devices for a user.
 - Query, used to check device state.
 - Execute, used to execute some command on device, e.g turn on lights.
-- Disconnect(G-Home only), disconnects user from a service.
+- Disconnect (Google Home only), disconnects user from a service.
 
-## lighthouse/
+### lighthouse/
 
 Handles websocket connections with embedded devices.
 
-## oauth/
+### oauth/
 
 Handles OAuth2 requests from G-Home.
 
-## token_blacklist/
+### token_blacklist/
 
-Store for refresh tokens, used to invalidate them in case something happens. [Sled](https://github.com/spacejam/sled) is used by default, but any database is supported because of available `TokenBlacklist` interface.
+Store for refresh tokens, used to invalidate them in case something happens.
+[Sled](https://github.com/spacejam/sled) is used by default, but any database is supported because
+of available `TokenBlacklist` interface.
 
-## extractors.rs
+### extractors.rs
 
 Axum extractors for things such as RefreshToken or AccessToken.

--- a/server/README.md
+++ b/server/README.md
@@ -9,6 +9,14 @@ The server currently supports two type of clients:
 - Internal, e.g CLI app
 - Google Home
 
+## Backends
+
+Devices may come from one of two sources, configured per user:
+
+- Lighthouse, a custom protocol defined by Houseflow.
+- [Homie](docs/homie.md), a [convention for IoT devices](https://homieiot.github.io/) defined on top
+  of MQTT.
+
 ## Code organisation
 
 The main modules and directories are:

--- a/server/docs/homie.md
+++ b/server/docs/homie.md
@@ -1,0 +1,37 @@
+# Homie integration
+
+Houseflow can be configured to act as a [Homie](https://homieiot.github.io/) controller, exposing
+supported Homie devices to Google Home.
+
+## Configuration
+
+To enable Homie integration, first enable Google login in your `server.toml`:
+
+```toml
+[logins.google]
+client-id = "my-client.apps.googleusercontent.com"
+```
+
+Then for each user whose devices should come from Homie, configure the MQTT broker and topic prefix:
+
+```toml
+[[users]]
+id = "uuidabc123"
+username = "someexampleuser"
+email = "someexampleuser@gmail.com"
+admin = false
+homie = { host = "mqtt.myserver.example", port = 8883, use-tls = true, username = "exampleuser", password = "somemqttpassword", client-id = "houseflow_homie_exampleuser", homie-prefix = "homie", reconnect-interval-seconds = 600 }
+```
+
+## Device mapping
+
+The Houseflow server will map Homie device nodes to Google Home devices, depending on their properties. Currently it supports these types:
+
+| Google Home device type | Google Home device trait | Homie property id | Homie data type  | Notes                                                                                               |
+| ----------------------- | ------------------------ | ----------------- | ---------------- | --------------------------------------------------------------------------------------------------- |
+| Switch                  | OnOff                    | `on`              | boolean          |                                                                                                     |
+| Light                   | OnOff                    | `on`              | boolean          | Must also have a `brightness` or `color` property to be recognised as a light rather than a switch. |
+|                         | Brightness               | `brightness`      | integer or float | Optional. Must include a `$format` specifying the range.                                            |
+|                         | ColorSetting             | `color`           | color            | Optional. Both RGB and HSV are supported.                                                           |
+| Thermostat              | TemperatureSetting       | `temperature`     | integer or float | Temperature is assumed to be in °C.                                                                 |
+|                         |                          | `humidity`        | integer or float | Optional.                                                                                           |

--- a/server/src/fulfillment/ghome/execute.rs
+++ b/server/src/fulfillment/ghome/execute.rs
@@ -1,3 +1,4 @@
+use super::homie::color_absolute_to_property_value;
 use super::homie::get_homie_device_by_id;
 use super::homie::percentage_to_property_value;
 use crate::State;
@@ -93,6 +94,31 @@ async fn execute_homie_device(
                     {
                         return if controller
                             .set(&device.id, &node.id, "brightness", value)
+                            .await
+                            .is_err()
+                        {
+                            response::PayloadCommand {
+                                ids,
+                                status: response::PayloadCommandStatus::Error,
+                                states: Default::default(),
+                                error_code: Some("transientError".to_string()),
+                            }
+                        } else {
+                            response::PayloadCommand {
+                                ids,
+                                status: response::PayloadCommandStatus::Pending,
+                                states: Default::default(),
+                                error_code: None,
+                            }
+                        };
+                    }
+                }
+            }
+            GHomeCommand::ColorAbsolute(color_absolute) => {
+                if let Some(color) = node.properties.get("color") {
+                    if let Some(value) = color_absolute_to_property_value(color, color_absolute) {
+                        return if controller
+                            .set(&device.id, &node.id, "color", value)
                             .await
                             .is_err()
                         {

--- a/server/src/fulfillment/ghome/execute.rs
+++ b/server/src/fulfillment/ghome/execute.rs
@@ -8,6 +8,7 @@ use google_smart_home::execute::request;
 use google_smart_home::execute::request::PayloadCommandDevice;
 use google_smart_home::execute::request::PayloadCommandExecution;
 use google_smart_home::execute::response;
+use homie_controller::Datatype;
 use homie_controller::Device;
 use homie_controller::HomieController;
 use homie_controller::Node;
@@ -68,7 +69,9 @@ async fn execute_homie_device(
         match &execution.command {
             GHomeCommand::OnOff(onoff) => {
                 if let Some(on) = node.properties.get("on") {
-                    return set_value(controller, device, node, "on", onoff.on, ids).await;
+                    if on.datatype == Some(Datatype::Boolean) {
+                        return set_value(controller, device, node, "on", onoff.on, ids).await;
+                    }
                 }
             }
             GHomeCommand::BrightnessAbsolute(brightness_absolute) => {

--- a/server/src/fulfillment/ghome/homie.rs
+++ b/server/src/fulfillment/ghome/homie.rs
@@ -2,6 +2,7 @@ use homie_controller::Datatype;
 use homie_controller::Device;
 use homie_controller::Node;
 use homie_controller::Property;
+use serde_json::Number;
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 
@@ -56,6 +57,21 @@ pub fn percentage_to_property_value(property: &Property, percentage: u8) -> Opti
             let range: RangeInclusive<f64> = property.range().ok()?;
             let value = range.start() + percentage as f64 * (range.end() - range.start()) / 100.0;
             Some(format!("{}", value))
+        }
+        _ => None,
+    }
+}
+
+/// Converts the property value to a JSON number if it is an appropriate type.
+pub fn property_value_to_number(property: &Property) -> Option<Number> {
+    match property.datatype? {
+        Datatype::Integer => {
+            let value: i64 = property.value().ok()?;
+            Some(value.into())
+        }
+        Datatype::Float => {
+            let value = property.value().ok()?;
+            Number::from_f64(value)
         }
         _ => None,
     }

--- a/server/src/fulfillment/ghome/homie.rs
+++ b/server/src/fulfillment/ghome/homie.rs
@@ -43,6 +43,24 @@ pub fn property_value_to_percentage(property: &Property) -> Option<u8> {
     }
 }
 
+/// Converts a percentage to the appropriately scaled property value of the given property, if it has
+/// a range specified.
+pub fn percentage_to_property_value(property: &Property, percentage: u8) -> Option<String> {
+    match property.datatype? {
+        Datatype::Integer => {
+            let range: RangeInclusive<i64> = property.range().ok()?;
+            let value = range.start() + percentage as i64 * (range.end() - range.start()) / 100;
+            Some(format!("{}", value))
+        }
+        Datatype::Float => {
+            let range: RangeInclusive<f64> = property.range().ok()?;
+            let value = range.start() + percentage as f64 * (range.end() - range.start()) / 100.0;
+            Some(format!("{}", value))
+        }
+        _ => None,
+    }
+}
+
 fn cap<N: Copy + PartialOrd>(value: N, min: N, max: N) -> N {
     if value < min {
         min

--- a/server/src/fulfillment/ghome/homie.rs
+++ b/server/src/fulfillment/ghome/homie.rs
@@ -1,8 +1,15 @@
+use google_smart_home::device::commands::ColorAbsolute;
+use google_smart_home::device::commands::ColorValue;
+use homie_controller::ColorFormat;
+use homie_controller::ColorHsv;
+use homie_controller::ColorRgb;
 use homie_controller::Datatype;
 use homie_controller::Device;
 use homie_controller::Node;
 use homie_controller::Property;
+use serde_json::Map;
 use serde_json::Number;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 
@@ -77,6 +84,67 @@ pub fn property_value_to_number(property: &Property) -> Option<Number> {
     }
 }
 
+/// Converts the value of the given property to a Google Home JSON color value, if it is the
+/// appropriate type.
+pub fn property_value_to_color(property: &Property) -> Option<Map<String, Value>> {
+    let color_format = property.color_format().ok()?;
+    let mut color_value = Map::new();
+    match color_format {
+        ColorFormat::Rgb => {
+            let rgb: ColorRgb = property.value().ok()?;
+            let rgb_int = ((rgb.r as u32) << 16) + ((rgb.g as u32) << 8) + (rgb.b as u32);
+            color_value.insert("spectrumRgb".to_string(), Value::Number(rgb_int.into()))
+        }
+        ColorFormat::Hsv => {
+            let hsv: ColorHsv = property.value().ok()?;
+            let mut hsv_map = Map::new();
+            hsv_map.insert("hue".to_string(), Value::Number(hsv.h.into()));
+            hsv_map.insert(
+                "saturation".to_string(),
+                Value::Number(Number::from_f64(hsv.s as f64 / 100.0)?),
+            );
+            hsv_map.insert(
+                "value".to_string(),
+                Value::Number(Number::from_f64(hsv.v as f64 / 100.0)?),
+            );
+            color_value.insert("spectrumHsv".to_string(), Value::Object(hsv_map))
+        }
+    };
+    Some(color_value)
+}
+
+/// Converts a Google Home `ColorAbsolute` command to the appropriate value to set on the given
+/// Homie property, if it is the appropriate format.
+pub fn color_absolute_to_property_value(
+    property: &Property,
+    color_absolute: &ColorAbsolute,
+) -> Option<String> {
+    let color_format = property.color_format().ok()?;
+    match color_format {
+        ColorFormat::Rgb => {
+            if let ColorValue::Rgb { spectrum_rgb } = color_absolute.color.value {
+                let rgb = ColorRgb::new(
+                    (spectrum_rgb >> 16) as u8,
+                    (spectrum_rgb >> 8) as u8,
+                    spectrum_rgb as u8,
+                );
+                return Some(rgb.to_string());
+            }
+        }
+        ColorFormat::Hsv => {
+            if let ColorValue::Hsv { spectrum_hsv } = &color_absolute.color.value {
+                let hsv = ColorHsv::new(
+                    spectrum_hsv.hue as u16,
+                    (spectrum_hsv.saturation * 100.0) as u8,
+                    (spectrum_hsv.value * 100.0) as u8,
+                );
+                return Some(hsv.to_string());
+            }
+        }
+    }
+    None
+}
+
 fn cap<N: Copy + PartialOrd>(value: N, min: N, max: N) -> N {
     if value < min {
         min
@@ -84,5 +152,30 @@ fn cap<N: Copy + PartialOrd>(value: N, min: N, max: N) -> N {
         max
     } else {
         value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_rgb() {
+        let property = Property {
+            id: "color".to_string(),
+            name: Some("Colour".to_string()),
+            datatype: Some(Datatype::Color),
+            settable: true,
+            retained: true,
+            unit: None,
+            format: Some("rgb".to_string()),
+            value: Some("17,34,51".to_string()),
+        };
+
+        let json_value = property_value_to_color(&property).unwrap();
+        assert_eq!(
+            json_value.get("spectrumRgb"),
+            Some(&Value::Number(0x112233.into()))
+        );
     }
 }

--- a/server/src/fulfillment/ghome/homie.rs
+++ b/server/src/fulfillment/ghome/homie.rs
@@ -1,0 +1,20 @@
+use homie_controller::Device;
+use homie_controller::Node;
+use std::collections::HashMap;
+
+/// Given an ID of the form `"device_id/node_id"`, looks up the corresponding Homie node (if any).
+pub fn get_homie_device_by_id<'a>(
+    devices: &'a HashMap<String, Device>,
+    id: &str,
+) -> Option<(&'a Device, &'a Node)> {
+    let id_parts: Vec<_> = id.split('/').collect();
+    if let [device_id, node_id] = id_parts.as_slice() {
+        if let Some(device) = devices.get(*device_id) {
+            if let Some(node) = device.nodes.get(*node_id) {
+                return Some((device, node));
+            }
+        }
+    }
+
+    None
+}

--- a/server/src/fulfillment/ghome/mod.rs
+++ b/server/src/fulfillment/ghome/mod.rs
@@ -1,4 +1,5 @@
 mod execute;
+mod homie;
 mod query;
 mod sync;
 

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -1,4 +1,5 @@
 use super::homie::get_homie_device_by_id;
+use super::homie::property_value_to_percentage;
 use crate::State;
 use google_smart_home::query::request;
 use google_smart_home::query::response;
@@ -60,9 +61,8 @@ fn get_homie_device(
                 }
             }
             if let Some(brightness) = node.properties.get("brightness") {
-                if let Ok(value) = brightness.value::<i64>() {
-                    // TODO: Scale to percentage.
-                    state.insert("brightness".to_string(), Value::Number(value.into()));
+                if let Some(percentage) = property_value_to_percentage(brightness) {
+                    state.insert("brightness".to_string(), Value::Number(percentage.into()));
                 }
             }
             if let Some(on) = node.properties.get("temperature") {

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -1,4 +1,5 @@
 use super::homie::get_homie_device_by_id;
+use super::homie::property_value_to_number;
 use super::homie::property_value_to_percentage;
 use crate::State;
 use google_smart_home::query::request;
@@ -9,7 +10,6 @@ use houseflow_types::errors::InternalError;
 use houseflow_types::lighthouse;
 use houseflow_types::user;
 use serde_json::Map;
-use serde_json::Number;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -65,14 +65,12 @@ fn get_homie_device(
                     state.insert("brightness".to_string(), Value::Number(percentage.into()));
                 }
             }
-            if let Some(on) = node.properties.get("temperature") {
-                if let Ok(value) = on.value::<f64>() {
-                    if let Some(finite_number) = Number::from_f64(value) {
-                        state.insert(
-                            "thermostatTemperatureAmbient".to_string(),
-                            Value::Number(finite_number),
-                        );
-                    }
+            if let Some(temperature) = node.properties.get("temperature") {
+                if let Some(finite_number) = property_value_to_number(temperature) {
+                    state.insert(
+                        "thermostatTemperatureAmbient".to_string(),
+                        Value::Number(finite_number),
+                    );
                 }
             }
 

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -13,66 +13,68 @@ pub async fn handle(
     user_id: user::ID,
     payload: &request::Payload,
 ) -> Result<response::Payload, InternalError> {
-    let sessions = &state.sessions;
-    let config = &state.config;
     let user_id = &user_id;
 
-    let responses = payload.devices.iter().map(|device| async move {
-        async {
-            let device_id = device::ID::from_str(&device.id).expect("invalid device ID");
-            if config.get_permission(&device_id, user_id).is_none() {
-                return Ok::<_, InternalError>(response::PayloadDevice {
-                    status: response::PayloadDeviceStatus::Error,
-                    state: Default::default(),
-                    error_code: Some(String::from("authFailure")),
-                });
-            }
-            let session = match sessions.get(&device_id) {
-                Some(session) => session.clone(),
-                None => {
-                    return Ok(response::PayloadDevice {
-                        state: Default::default(),
-                        status: response::PayloadDeviceStatus::Offline,
-                        error_code: Some(String::from("offline")),
-                    })
-                }
-            };
-
-            let request = lighthouse::query::Frame {};
-            let response = match tokio::time::timeout(
-                crate::fulfillment::EXECUTE_TIMEOUT,
-                session.query(request),
-            )
-            .await
-            {
-                Ok(val) => val?,
-                Err(_) => {
-                    return Ok(response::PayloadDevice {
-                        status: response::PayloadDeviceStatus::Offline,
-                        state: Default::default(),
-                        error_code: Some(String::from("offline")),
-                    })
-                }
-            };
-
-            tracing::info!(state = %serde_json::to_string(&response.state).unwrap(),
-                "Queried device state");
-
-            Ok(response::PayloadDevice {
-                status: response::PayloadDeviceStatus::Success,
-                error_code: None,
-                state: response.state,
-            })
-        }
-        .await
-        .map(|response| (device.id.to_owned(), response))
+    let responses = payload.devices.iter().map(|device| async {
+        let response = get_lighthouse_device(&state, user_id, device).await?;
+        Ok::<_, InternalError>((device.id.to_owned(), response))
     });
+    let devices = futures::future::try_join_all(responses)
+        .await?
+        .into_iter()
+        .collect();
     Ok(response::Payload {
         error_code: None,
         debug_string: None,
-        devices: futures::future::try_join_all(responses)
-            .await?
-            .into_iter()
-            .collect(),
+        devices,
+    })
+}
+
+async fn get_lighthouse_device(
+    state: &State,
+    user_id: &user::ID,
+    device: &request::PayloadDevice,
+) -> Result<response::PayloadDevice, InternalError> {
+    let device_id = device::ID::from_str(&device.id).expect("invalid device ID");
+
+    if state.config.get_permission(&device_id, user_id).is_none() {
+        return Ok(response::PayloadDevice {
+            status: response::PayloadDeviceStatus::Error,
+            state: Default::default(),
+            error_code: Some(String::from("authFailure")),
+        });
+    }
+    let session = match state.sessions.get(&device_id) {
+        Some(session) => session.clone(),
+        None => {
+            return Ok(response::PayloadDevice {
+                state: Default::default(),
+                status: response::PayloadDeviceStatus::Offline,
+                error_code: Some(String::from("offline")),
+            })
+        }
+    };
+
+    let request = lighthouse::query::Frame {};
+    let response =
+        match tokio::time::timeout(crate::fulfillment::EXECUTE_TIMEOUT, session.query(request))
+            .await
+        {
+            Ok(val) => val?,
+            Err(_) => {
+                return Ok(response::PayloadDevice {
+                    status: response::PayloadDeviceStatus::Offline,
+                    state: Default::default(),
+                    error_code: Some(String::from("offline")),
+                })
+            }
+        };
+
+    tracing::info!(state = %serde_json::to_string(&response.state).unwrap(), "Queried device state");
+
+    Ok(response::PayloadDevice {
+        status: response::PayloadDeviceStatus::Success,
+        error_code: None,
+        state: response.state,
     })
 }

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -18,7 +18,7 @@ pub async fn handle(
     let user_id = &user_id;
 
     let responses = payload.devices.iter().map(|device| async move {
-        let response = (|| async {
+        async {
             let device_id = device::ID::from_str(&device.id).expect("invalid device ID");
             if config.get_permission(&device_id, user_id).is_none() {
                 return Ok::<_, InternalError>(response::PayloadDevice {
@@ -55,17 +55,17 @@ pub async fn handle(
                 }
             };
 
-            tracing::info!(state = %serde_json::to_string(&response.state).unwrap(), "Queried device state");
+            tracing::info!(state = %serde_json::to_string(&response.state).unwrap(),
+                "Queried device state");
 
             Ok(response::PayloadDevice {
                 status: response::PayloadDeviceStatus::Success,
                 error_code: None,
                 state: response.state,
             })
-        })();
-        response
-            .await
-            .map(|response| (device.id.to_owned(), response))
+        }
+        .await
+        .map(|response| (device.id.to_owned(), response))
     });
     Ok(response::Payload {
         error_code: None,

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -33,6 +33,7 @@ async fn get_lighthouse_device(
     user_id: &user::ID,
     device: &request::PayloadDevice,
 ) -> Result<response::PayloadDevice, InternalError> {
+    // TODO: Return error rather than panicking.
     let device_id = device::ID::from_str(&device.id).expect("invalid device ID");
 
     if state.config.get_permission(&device_id, user_id).is_none() {

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -1,4 +1,5 @@
 use super::homie::get_homie_device_by_id;
+use super::homie::property_value_to_color;
 use super::homie::property_value_to_number;
 use super::homie::property_value_to_percentage;
 use crate::State;
@@ -63,6 +64,11 @@ fn get_homie_device(
             if let Some(brightness) = node.properties.get("brightness") {
                 if let Some(percentage) = property_value_to_percentage(brightness) {
                     state.insert("brightness".to_string(), Value::Number(percentage.into()));
+                }
+            }
+            if let Some(color) = node.properties.get("color") {
+                if let Some(color_value) = property_value_to_color(color) {
+                    state.insert("color".to_string(), Value::Object(color_value));
                 }
             }
             if let Some(temperature) = node.properties.get("temperature") {

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -13,10 +13,8 @@ pub async fn handle(
     user_id: user::ID,
     payload: &request::Payload,
 ) -> Result<response::Payload, InternalError> {
-    let user_id = &user_id;
-
     let responses = payload.devices.iter().map(|device| async {
-        let response = get_lighthouse_device(&state, user_id, device).await?;
+        let response = get_lighthouse_device(&state, &user_id, device).await?;
         Ok::<_, InternalError>((device.id.to_owned(), response))
     });
     let devices = futures::future::try_join_all(responses)

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -1,10 +1,15 @@
 use crate::State;
 use google_smart_home::query::request;
 use google_smart_home::query::response;
+use homie_controller::Device;
 use houseflow_types::device;
 use houseflow_types::errors::InternalError;
 use houseflow_types::lighthouse;
 use houseflow_types::user;
+use serde_json::Map;
+use serde_json::Number;
+use serde_json::Value;
+use std::collections::HashMap;
 use std::str::FromStr;
 
 #[tracing::instrument(name = "Query", skip(state), err)]
@@ -13,19 +18,102 @@ pub async fn handle(
     user_id: user::ID,
     payload: &request::Payload,
 ) -> Result<response::Payload, InternalError> {
-    let responses = payload.devices.iter().map(|device| async {
-        let response = get_lighthouse_device(&state, &user_id, device).await?;
-        Ok::<_, InternalError>((device.id.to_owned(), response))
-    });
-    let devices = futures::future::try_join_all(responses)
-        .await?
-        .into_iter()
-        .collect();
+    let devices = if let Some(homie_controller) = state.homie_controllers.get(&user_id) {
+        get_homie_devices(&homie_controller.devices(), &payload.devices)
+    } else {
+        get_lighthouse_devices(&state, &user_id, &payload.devices).await?
+    };
     Ok(response::Payload {
         error_code: None,
         debug_string: None,
         devices,
     })
+}
+
+fn get_homie_devices(
+    devices: &HashMap<String, Device>,
+    request_devices: &[request::PayloadDevice],
+) -> HashMap<String, response::PayloadDevice> {
+    request_devices
+        .iter()
+        .map(|device| {
+            let response = get_homie_device(devices, device);
+            (device.id.to_owned(), response)
+        })
+        .collect()
+}
+
+fn get_homie_device(
+    devices: &HashMap<String, Device>,
+    request_device: &request::PayloadDevice,
+) -> response::PayloadDevice {
+    let id_parts: Vec<_> = request_device.id.split('/').collect();
+    if let [device_id, node_id] = id_parts.as_slice() {
+        if let Some(device) = devices.get(*device_id) {
+            if device.state == homie_controller::State::Ready
+                || device.state == homie_controller::State::Sleeping
+            {
+                if let Some(node) = device.nodes.get(*node_id) {
+                    let mut state = Map::new();
+
+                    if let Some(on) = node.properties.get("on") {
+                        if let Ok(value) = on.value() {
+                            state.insert("on".to_string(), Value::Bool(value));
+                        }
+                    }
+                    if let Some(brightness) = node.properties.get("brightness") {
+                        if let Ok(value) = brightness.value::<i64>() {
+                            // TODO: Scale to percentage.
+                            state.insert("brightness".to_string(), Value::Number(value.into()));
+                        }
+                    }
+                    if let Some(on) = node.properties.get("temperature") {
+                        if let Ok(value) = on.value::<f64>() {
+                            if let Some(finite_number) = Number::from_f64(value) {
+                                state.insert(
+                                    "thermostatTemperatureAmbient".to_string(),
+                                    Value::Number(finite_number),
+                                );
+                            }
+                        }
+                    }
+
+                    return response::PayloadDevice {
+                        state,
+                        status: response::PayloadDeviceStatus::Success,
+                        error_code: None,
+                    };
+                }
+            } else {
+                return response::PayloadDevice {
+                    state: Default::default(),
+                    status: response::PayloadDeviceStatus::Offline,
+                    error_code: Some("offline".to_string()),
+                };
+            }
+        }
+    }
+
+    response::PayloadDevice {
+        status: response::PayloadDeviceStatus::Error,
+        state: Default::default(),
+        error_code: Some("deviceNotFound".to_string()),
+    }
+}
+
+async fn get_lighthouse_devices(
+    state: &State,
+    user_id: &user::ID,
+    devices: &[request::PayloadDevice],
+) -> Result<HashMap<String, response::PayloadDevice>, InternalError> {
+    let responses = devices.iter().map(|device| async {
+        let response = get_lighthouse_device(state, user_id, device).await?;
+        Ok::<_, InternalError>((device.id.to_owned(), response))
+    });
+    Ok(futures::future::try_join_all(responses)
+        .await?
+        .into_iter()
+        .collect())
 }
 
 async fn get_lighthouse_device(

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -73,6 +73,14 @@ fn get_homie_device(
                     );
                 }
             }
+            if let Some(humidity) = node.properties.get("humidity") {
+                if let Some(finite_number) = property_value_to_number(humidity) {
+                    state.insert(
+                        "thermostatHumidityAmbient".to_string(),
+                        Value::Number(finite_number),
+                    );
+                }
+            }
 
             response::PayloadDevice {
                 state,

--- a/server/src/fulfillment/ghome/sync.rs
+++ b/server/src/fulfillment/ghome/sync.rs
@@ -5,6 +5,7 @@ use google_smart_home::device::Trait as GHomeDeviceTrait;
 use google_smart_home::device::Type as GHomeDeviceType;
 use google_smart_home::sync::response;
 use google_smart_home::sync::response::PayloadDevice;
+use homie_controller::ColorFormat;
 use homie_controller::Device;
 use homie_controller::Node;
 use houseflow_config::server::Config;
@@ -122,6 +123,20 @@ fn homie_node_to_google_home(device: &Device, node: &Node) -> Option<PayloadDevi
             device_type = Some(GHomeDeviceType::Light);
         }
         traits.push(GHomeDeviceTrait::Brightness);
+    }
+    if let Some(color) = node.properties.get("color") {
+        if let Ok(color_format) = color.color_format() {
+            let color_model = match color_format {
+                ColorFormat::Rgb => "rgb",
+                ColorFormat::Hsv => "hsv",
+            };
+            device_type = Some(GHomeDeviceType::Light);
+            traits.push(GHomeDeviceTrait::ColorSetting);
+            attributes.insert(
+                "colorModel".to_string(),
+                Value::String(color_model.to_owned()),
+            );
+        }
     }
     if node.properties.contains_key("temperature") {
         device_type = Some(GHomeDeviceType::Thermostat);

--- a/server/src/fulfillment/ghome/sync.rs
+++ b/server/src/fulfillment/ghome/sync.rs
@@ -1,7 +1,11 @@
+use std::collections::HashMap;
+
 use crate::State;
 use google_smart_home::device::Trait as GHomeDeviceTrait;
 use google_smart_home::device::Type as GHomeDeviceType;
 use google_smart_home::sync::response;
+use google_smart_home::sync::response::PayloadDevice;
+use homie_controller::Device;
 use houseflow_types::device::Trait as DeviceTrait;
 use houseflow_types::device::Type as DeviceType;
 use houseflow_types::errors::InternalError;
@@ -10,55 +14,58 @@ use houseflow_types::user;
 
 #[tracing::instrument(name = "Sync", skip(state), err)]
 pub async fn handle(state: State, user_id: user::ID) -> Result<response::Payload, ServerError> {
-    let user_devices = state.config.get_user_devices(&user_id);
+    let user_devices = if let Some(homie_controller) = state.homie_controllers.get(&user_id) {
+        homie_devices_to_google_home(&homie_controller.devices())
+    } else {
+        let user_devices = state.config.get_user_devices(&user_id);
 
-    let user_devices = user_devices
-        .into_iter()
-        .map(|device_id| state.config.get_device(&device_id).unwrap())
-        .map(|device| {
-            let room = state
-                .config
-                .get_room(&device.room_id)
-                .ok_or_else(|| InternalError::Other("couldn't find matching room".to_string()))?;
-            let payload = response::PayloadDevice {
-                id: device.id.to_string(),
-                device_type: match device.device_type {
-                    DeviceType::Garage => GHomeDeviceType::Garage,
-                    DeviceType::Gate => GHomeDeviceType::Gate,
-                    DeviceType::Light => GHomeDeviceType::Light,
-                    _ => todo!(),
-                },
-                traits: device
-                    .traits
-                    .iter()
-                    .map(|t| match t {
-                        DeviceTrait::OnOff => GHomeDeviceTrait::OnOff,
-                        DeviceTrait::OpenClose => GHomeDeviceTrait::OpenClose,
+        user_devices
+            .into_iter()
+            .map(|device_id| state.config.get_device(&device_id).unwrap())
+            .map(|device| {
+                let room = state.config.get_room(&device.room_id).ok_or_else(|| {
+                    InternalError::Other("couldn't find matching room".to_string())
+                })?;
+                let payload = response::PayloadDevice {
+                    id: device.id.to_string(),
+                    device_type: match device.device_type {
+                        DeviceType::Garage => GHomeDeviceType::Garage,
+                        DeviceType::Gate => GHomeDeviceType::Gate,
+                        DeviceType::Light => GHomeDeviceType::Light,
                         _ => todo!(),
-                    })
-                    .collect(),
-                name: response::PayloadDeviceName {
-                    default_names: None,
-                    name: device.name,
-                    nicknames: None,
-                },
-                will_report_state: device.will_push_state,
-                notification_supported_by_agent: false, // not sure about that
-                room_hint: Some(room.name),
-                device_info: Some(response::PayloadDeviceInfo {
-                    manufacturer: Some("houseflow".to_string()),
-                    model: None,
-                    hw_version: Some(device.hw_version.to_string()),
-                    sw_version: Some(device.sw_version.to_string()),
-                }),
-                attributes: device.attributes,
-                custom_data: None,
-                other_device_ids: None,
-            };
+                    },
+                    traits: device
+                        .traits
+                        .iter()
+                        .map(|t| match t {
+                            DeviceTrait::OnOff => GHomeDeviceTrait::OnOff,
+                            DeviceTrait::OpenClose => GHomeDeviceTrait::OpenClose,
+                            _ => todo!(),
+                        })
+                        .collect(),
+                    name: response::PayloadDeviceName {
+                        default_names: None,
+                        name: device.name,
+                        nicknames: None,
+                    },
+                    will_report_state: device.will_push_state,
+                    notification_supported_by_agent: false, // not sure about that
+                    room_hint: Some(room.name),
+                    device_info: Some(response::PayloadDeviceInfo {
+                        manufacturer: Some("houseflow".to_string()),
+                        model: None,
+                        hw_version: Some(device.hw_version.to_string()),
+                        sw_version: Some(device.sw_version.to_string()),
+                    }),
+                    attributes: device.attributes,
+                    custom_data: None,
+                    other_device_ids: None,
+                };
 
-            Ok::<_, ServerError>(payload)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+                Ok::<_, ServerError>(payload)
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
 
     tracing::info!("Synced {} devices", user_devices.len());
 
@@ -68,4 +75,27 @@ pub async fn handle(state: State, user_id: user::ID) -> Result<response::Payload
         debug_string: None,
         devices: user_devices,
     })
+}
+
+fn homie_devices_to_google_home(devices: &HashMap<String, Device>) -> Vec<PayloadDevice> {
+    devices
+        .values()
+        .map(|device| response::PayloadDevice {
+            id: device.id.clone(),
+            device_type: GHomeDeviceType::Light,
+            traits: vec![GHomeDeviceTrait::OnOff],
+            name: response::PayloadDeviceName {
+                default_names: None,
+                name: device.name.clone().unwrap_or_else(|| device.id.clone()),
+                nicknames: None,
+            },
+            device_info: None,
+            will_report_state: false,
+            notification_supported_by_agent: false,
+            room_hint: None,
+            attributes: Default::default(),
+            custom_data: None,
+            other_device_ids: None,
+        })
+        .collect()
 }

--- a/server/src/fulfillment/ghome/sync.rs
+++ b/server/src/fulfillment/ghome/sync.rs
@@ -106,7 +106,9 @@ fn homie_node_to_google_home(device_id: &str, node: &Node) -> Option<PayloadDevi
         traits.push(GHomeDeviceTrait::OnOff);
     }
     if node.properties.contains_key("brightness") {
-        device_type = Some(GHomeDeviceType::Light);
+        if node.properties.contains_key("on") {
+            device_type = Some(GHomeDeviceType::Light);
+        }
         traits.push(GHomeDeviceTrait::Brightness);
     }
     if node.properties.contains_key("temperature") {

--- a/server/src/fulfillment/ghome/sync.rs
+++ b/server/src/fulfillment/ghome/sync.rs
@@ -70,7 +70,11 @@ pub async fn handle(state: State, user_id: user::ID) -> Result<response::Payload
             .collect::<Result<Vec<_>, _>>()?
     };
 
-    tracing::info!("Synced {} devices", user_devices.len());
+    tracing::info!(
+        "Synced {} devices: {}",
+        user_devices.len(),
+        serde_json::to_string_pretty(&user_devices).unwrap(),
+    );
 
     Ok(response::Payload {
         agent_user_id: user_id.to_string(),

--- a/server/src/homie.rs
+++ b/server/src/homie.rs
@@ -66,6 +66,6 @@ pub fn spawn_homie_poller(
 async fn handle_homie_event(_controller: &HomieController, event: Event) {
     match event {
         Event::PropertyValueChanged { .. } => {}
-        _ => tracing::info!("Homie event {:?}", event),
+        _ => tracing::trace!("Homie event {:?}", event),
     }
 }

--- a/server/src/homie.rs
+++ b/server/src/homie.rs
@@ -1,0 +1,69 @@
+use homie_controller::Event;
+use homie_controller::HomieController;
+use homie_controller::HomieEventLoop;
+use homie_controller::PollError;
+use houseflow_types::user::Homie;
+use rumqttc::ClientConfig;
+use rumqttc::ConnectionError;
+use rumqttc::MqttOptions;
+use rumqttc::TlsConfiguration;
+use rumqttc::Transport;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task;
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+
+pub fn get_mqtt_options(
+    config: &Homie,
+    tls_client_config: Option<Arc<ClientConfig>>,
+) -> MqttOptions {
+    let mut mqtt_options = MqttOptions::new(&config.client_id, &config.host, config.port);
+    mqtt_options.set_keep_alive(5);
+    mqtt_options.set_clean_session(false);
+
+    if let (Some(username), Some(password)) = (&config.username, &config.password) {
+        mqtt_options.set_credentials(username, password);
+    }
+
+    if let Some(client_config) = tls_client_config {
+        mqtt_options.set_transport(Transport::tls_with_config(TlsConfiguration::Rustls(
+            client_config,
+        )));
+    }
+
+    mqtt_options
+}
+
+pub fn spawn_homie_poller(
+    controller: Arc<HomieController>,
+    mut event_loop: HomieEventLoop,
+    reconnect_interval: Duration,
+) -> JoinHandle<()> {
+    task::spawn(async move {
+        loop {
+            match controller.poll(&mut event_loop).await {
+                Ok(Some(event)) => {
+                    handle_homie_event(controller.as_ref(), event).await;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to poll HomieController for base topic '{}': {}",
+                        controller.base_topic(),
+                        e
+                    );
+                    if let PollError::Connection(ConnectionError::Io(_)) = e {
+                        sleep(reconnect_interval).await;
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn handle_homie_event(_controller: &HomieController, event: Event) {
+    match event {
+        _ => tracing::info!("Homie event {:?}", event),
+    }
+}

--- a/server/src/homie.rs
+++ b/server/src/homie.rs
@@ -65,6 +65,7 @@ pub fn spawn_homie_poller(
 
 async fn handle_homie_event(_controller: &HomieController, event: Event) {
     match event {
+        Event::PropertyValueChanged { .. } => {}
         _ => tracing::info!("Homie event {:?}", event),
     }
 }

--- a/server/src/homie.rs
+++ b/server/src/homie.rs
@@ -20,7 +20,8 @@ pub fn get_mqtt_options(
 ) -> MqttOptions {
     let mut mqtt_options = MqttOptions::new(&config.client_id, &config.host, config.port);
     mqtt_options.set_keep_alive(5);
-    mqtt_options.set_clean_session(false);
+    // TODO: This is needs to be false for the initial connection to work, but what about reconnection?
+    mqtt_options.set_clean_session(true);
 
     if let (Some(username), Some(password)) = (&config.username, &config.password) {
         mqtt_options.set_credentials(username, password);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,15 +3,19 @@ mod extractors;
 mod auth;
 pub mod clerk;
 mod fulfillment;
+pub mod homie;
 mod lighthouse;
 pub mod mailer;
 mod oauth;
 
 use axum::Router;
 use dashmap::DashMap;
+use homie_controller::HomieController;
 use houseflow_config::server::Config;
 use houseflow_types::device;
+use houseflow_types::user;
 use mailer::Mailer;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 async fn health_check() -> &'static str {
@@ -24,6 +28,7 @@ pub struct State {
     pub mailer: Arc<dyn Mailer>,
     pub config: Arc<Config>,
     pub sessions: Arc<DashMap<device::ID, lighthouse::Session>>,
+    pub homie_controllers: Arc<HashMap<user::ID, Arc<HomieController>>>,
 }
 
 pub fn app(state: State) -> Router<hyper::Body> {
@@ -102,6 +107,7 @@ mod test_utils {
     use houseflow_config::server::Network;
     use houseflow_config::server::Secrets;
     use houseflow_types::code::VerificationCode;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
     use url::Url;
@@ -164,6 +170,7 @@ mod test_utils {
             mailer: Arc::new(FakeMailer::new(tx.clone())),
             sessions,
             clerk: Arc::new(Clerk::new_temporary(clerk_path).unwrap()),
+            homie_controllers: Arc::new(HashMap::new()),
         })
     }
 
@@ -174,6 +181,7 @@ mod test_utils {
             username: format!("john-{}", id.clone()),
             email: format!("john-{}@example.com", id.clone()),
             admin: false,
+            homie: None,
         }
     }
 

--- a/types/src/user.rs
+++ b/types/src/user.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
+use std::time::Duration;
 use uuid::Uuid;
 
 pub type ID = Uuid;
@@ -14,4 +16,45 @@ pub struct User {
     pub email: String,
     /// True if the user is admin.
     pub admin: bool,
+    /// Homie controller for the user.
+    #[serde(default)]
+    pub homie: Option<Homie>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Homie {
+    /// The hostname of the MQTT broker.
+    pub host: String,
+    /// The port of the MQTT broker.
+    pub port: u16,
+    /// Whether to use TLS for the MQTT broker connection.
+    #[serde(default)]
+    pub use_tls: bool,
+    /// The username with which to authenticate to the MQTT broker, if any.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// The password with which to authenticate to the MQTT broker, if any.
+    #[serde(default)]
+    pub password: Option<String>,
+    /// The client ID to use for the MQTT connection.
+    pub client_id: String,
+    /// The Homie base MQTT topic.
+    #[serde(default = "default_homie_prefix")]
+    pub homie_prefix: String,
+    #[serde(
+        deserialize_with = "de_duration_seconds",
+        rename = "reconnect-interval-seconds"
+    )]
+    pub reconnect_interval: Duration,
+}
+
+fn default_homie_prefix() -> String {
+    "homie".to_string()
+}
+
+/// Deserialize an integer as a number of seconds.
+fn de_duration_seconds<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+    let seconds = u64::deserialize(d)?;
+    Ok(Duration::from_secs(seconds))
 }


### PR DESCRIPTION
This implements #197. It builds on top of #237 so it would be best to merge that first.

I realise this isn't a direction you are particularly interested in, but it's still something I'd like to support so I'm sending this PR with what I have so far so we can discuss where to take this. I can see three options:

1. Add Homie support to the existing `houseflow-server`, configurable through the server config file. If you keep the current configuration it will do nothing, if you want to enable the Homie controller you can configure it per user and it will be used instead of Lighthouse and the configured set of devices for that user. This is the option I've taken so far in this PR.
2. Leave `houseflow-server` as-is, but add a new crate to this repository which shares code which is like `houseflow-server` but uses Homie as a backend rather than Lighthouse. This would share quite a bit of code with `houseflow-server` so maybe some of the common code could be factored out to another crate.
3. I create the new crate like the second option, but in a separate repository. This would at least use the existing `google-smart-home` crate, and perhaps some of the other shared code from `houseflow-server` could also be factored out to a new crate.

What do you think? Do you have any preferences among these options, or any other options to consider?