### PR TITLE
Add structs for Google Home sync response attributes and query response state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Install dependencies
+        run: sudo apt-get install libdbus-1-dev
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -54,6 +57,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Install dependencies
+        run: sudo apt-get install libdbus-1-dev
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -94,6 +100,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Install dependencies
+        run: sudo apt-get install libdbus-1-dev
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/google-smart-home/src/lib.rs
+++ b/google-smart-home/src/lib.rs
@@ -28,7 +28,7 @@ pub enum RequestInput {
     Disconnect,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum Response {
     Sync(sync::response::Response),

--- a/google-smart-home/src/query.rs
+++ b/google-smart-home/src/query.rs
@@ -28,7 +28,7 @@ pub mod response {
     use super::*;
 
     /// QUERY response.
-    #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Response {
         pub request_id: String,
@@ -36,7 +36,7 @@ pub mod response {
     }
 
     /// QUERY response payload.
-    #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Payload {
         /// An error code for the entire transaction for auth failures and developer system unavailability.
@@ -53,7 +53,7 @@ pub mod response {
     }
 
     /// Device execution result.
-    #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct PayloadDevice {
         /// Result of the query operation.
@@ -64,7 +64,57 @@ pub mod response {
 
         /// Device state
         #[serde(default, flatten)]
-        pub state: serde_json::Map<String, serde_json::Value>,
+        pub state: State,
+    }
+
+    /// Device state.
+    #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct State {
+        // States common to all devices.
+        pub online: bool,
+
+        // States for OnOff trait.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub on: Option<bool>,
+
+        // States for Brightness trait.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub brightness: Option<u8>,
+
+        // States for ColorSetting trait.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub color: Option<Color>,
+
+        // States for TemperatureSetting trait.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub active_thermostat_mode: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub target_temp_reached_estimate_unix_timestamp_sec: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_humidity_ambient: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_mode: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_temperature_ambient: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_temperature_setpoint: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_temperature_setpoint_high: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_temperature_setpoint_low: Option<f64>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub enum Color {
+        TemperatureK(u64),
+        SpectrumRgb(u32),
+        SpectrumHsv {
+            hue: f64,
+            saturation: f64,
+            value: f64,
+        },
     }
 
     /// Result of the query operation.

--- a/google-smart-home/src/sync.rs
+++ b/google-smart-home/src/sync.rs
@@ -80,6 +80,59 @@ pub mod response {
         pub other_device_ids: Option<Vec<PayloadOtherDeviceID>>,
     }
 
+    #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Attributes {
+        // Attributes for ColorSetting trait.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub color_model: Option<ColorModel>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub color_temperature_range: Option<ColorTemperatureRange>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub command_only_color_setting: Option<bool>,
+
+        // Attributes for TemperatureSetting trait.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub available_thermostat_modes: Option<Vec<String>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub buffer_range_celsius: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub command_only_temperature_setting: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub query_only_temperature_setting: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_temperature_range: Option<ThermostatTemperatureRange>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub thermostat_temperature_unit: Option<ThermostatTemperatureUnit>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ColorTemperatureRange {
+        pub temperature_min_k: u64,
+        pub temperature_max_k: u64,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub enum ColorModel {
+        Rgb,
+        Hsv,
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ThermostatTemperatureRange {
+        pub min_threshold_celsius: f64,
+        pub max_threshold_celcius: f64,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    pub enum ThermostatTemperatureUnit {
+        C,
+        F,
+    }
+
     #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct PayloadDeviceName {
@@ -120,5 +173,25 @@ pub mod response {
         pub agent_id: Option<String>,
         /// Device ID defined by the agent. The device ID must be unique.
         pub device_id: String,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+
+    #[test]
+    fn color_setting_attributes() {
+        let attributes = response::Attributes {
+            color_model: Some(response::ColorModel::Rgb),
+            command_only_color_setting: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_string(&attributes).unwrap(),
+            json!({"colorModel": "rgb", "commandOnlyColorSetting": true}).to_string()
+        );
     }
 }

--- a/google-smart-home/src/sync.rs
+++ b/google-smart-home/src/sync.rs
@@ -17,7 +17,7 @@ pub mod response {
     use super::*;
 
     /// SYNC response
-    #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Response {
         pub request_id: String,
@@ -25,7 +25,7 @@ pub mod response {
     }
 
     /// SYNC response payload.
-    #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Payload {
         /// Reflects the unique (and immutable) user ID on the agent's platform.
@@ -42,7 +42,7 @@ pub mod response {
     }
 
     /// Device execution result.
-    #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+    #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct PayloadDevice {
         /// The ID of the device in the developer's cloud.
@@ -71,7 +71,7 @@ pub mod response {
         pub device_info: Option<PayloadDeviceInfo>,
         /// Aligned with per-trait attributes described in each trait schema reference.
         #[serde(default)]
-        pub attributes: serde_json::Map<String, serde_json::Value>,
+        pub attributes: Attributes,
         /// Object defined by the developer which will be attached to future QUERY and EXECUTE requests, maximum of 512 bytes per device. Use this object to store additional information about the device your cloud service may need, such as the global region of the device. Data in this object has a few constraints: No sensitive information, including but not limited to Personally Identifiable Information.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub custom_data: Option<serde_json::Map<String, serde_json::Value>>,

--- a/google-smart-home/tests/json/query/response.json
+++ b/google-smart-home/tests/json/query/response.json
@@ -13,8 +13,7 @@
         "status": "SUCCESS",
         "brightness": 80,
         "color": {
-          "name": "cerulean",
-          "spectrumRGB": 31655
+          "spectrumRgb": 31655
         }
       }
     }

--- a/google-smart-home/tests/query.rs
+++ b/google-smart-home/tests/query.rs
@@ -64,13 +64,11 @@ fn query_response() {
                         response::PayloadDevice {
                             status: response::PayloadDeviceStatus::Success,
                             error_code: None,
-                            state: json!({
-                                "on": true,
-                                "online": true,
-                            })
-                            .as_object()
-                            .unwrap()
-                            .clone(),
+                            state: response::State {
+                                online: true,
+                                on: Some(true),
+                                ..Default::default()
+                            },
                         },
                     ),
                     (
@@ -78,18 +76,13 @@ fn query_response() {
                         response::PayloadDevice {
                             status: response::PayloadDeviceStatus::Success,
                             error_code: None,
-                            state: json!({
-                                "on": true,
-                                "online": true,
-                                "brightness": 80,
-                                "color": {
-                                    "name": "cerulean",
-                                    "spectrumRGB": 31655
-                                },
-                            })
-                            .as_object()
-                            .unwrap()
-                            .clone(),
+                            state: response::State {
+                                online: true,
+                                on: Some(true),
+                                brightness: Some(80),
+                                color: Some(response::Color::SpectrumRgb(31655)),
+                                ..Default::default()
+                            },
                         },
                     ),
                 ]

--- a/google-smart-home/tests/sync.rs
+++ b/google-smart-home/tests/sync.rs
@@ -91,17 +91,15 @@ fn sync_response() {
                             hw_version: Some(String::from("1.2")),
                             sw_version: Some(String::from("5.4")),
                         }),
-                        attributes: json!({
-                            "colorModel": "rgb",
-                            "colorTemperatureRange": {
-                                "temperatureMinK": 2000,
-                                "temperatureMaxK": 9000
-                            },
-                            "commandOnlyColorSetting": false
-                        })
-                        .as_object()
-                        .unwrap()
-                        .to_owned(),
+                        attributes: response::Attributes {
+                            color_model: Some(response::ColorModel::Rgb),
+                            color_temperature_range: Some(response::ColorTemperatureRange {
+                                temperature_min_k: 2000,
+                                temperature_max_k: 9000,
+                            }),
+                            command_only_color_setting: Some(false),
+                            ..Default::default()
+                        },
                         custom_data: Some(
                             json!({
                                 "fooValue": 12,

--- a/server/src/fulfillment/ghome/query.rs
+++ b/server/src/fulfillment/ghome/query.rs
@@ -59,7 +59,7 @@ pub async fn handle(
             Ok(response::PayloadDevice {
                 status: response::PayloadDeviceStatus::Success,
                 error_code: None,
-                state: serde_json::json!({}).as_object().unwrap().clone(), // TODO: implement states
+                state: response::State::default(), // TODO: implement states
             })
         })();
         response

--- a/server/src/fulfillment/ghome/sync.rs
+++ b/server/src/fulfillment/ghome/sync.rs
@@ -29,7 +29,10 @@ pub async fn handle(state: State, user_id: user::ID) -> Result<response::Payload
                     manufacturers::XiaomiMijia::HygroThermometer => (
                         device::Type::Thermostat,
                         vec![device::Trait::TemperatureControl],
-                        json!({"queryOnlyTemperatureControl": true}),
+                        response::Attributes {
+                            query_only_temperature_control: Some(true),
+                            ..Default::default()
+                        },
                     ),
                     _ => unimplemented!(),
                 },
@@ -37,12 +40,12 @@ pub async fn handle(state: State, user_id: user::ID) -> Result<response::Payload
                     manufacturers::Houseflow::Garage => (
                         device::Type::Garage,
                         vec![device::Trait::OpenClose],
-                        json!({}),
+                        response::Attributes::default(),
                     ),
                     manufacturers::Houseflow::Gate => (
                         device::Type::Garage,
                         vec![device::Trait::OpenClose],
-                        json!({}),
+                        response::Attributes::default(),
                     ),
                     _ => unimplemented!(),
                 },
@@ -67,7 +70,7 @@ pub async fn handle(state: State, user_id: user::ID) -> Result<response::Payload
                     hw_version: None,
                     sw_version: None,
                 }),
-                attributes: attributes.as_object().unwrap().clone(),
+                attributes,
                 custom_data: None,
                 other_device_ids: None,
             }


### PR DESCRIPTION
These provide a typed way to construct attributes and state, rather than just a JSON map.

I also fixed a bug in the test where `spectrumRgb` had the wrong capitalisation and the `name` field was incorrectly added to the query response state. These appear to have been accidentally copied from the execute command.